### PR TITLE
Update 03.一文彻底搞懂ReactHooks的原理和实现.md

### DIFF
--- a/docs/ReactJS/03.一文彻底搞懂ReactHooks的原理和实现.md
+++ b/docs/ReactJS/03.一文彻底搞懂ReactHooks的原理和实现.md
@@ -170,7 +170,7 @@ function App() {
 | unusedNum | 1      |
 | num2      | 2      |
 
-当点击事件触发再次渲染，并不会进入条件判断中的 useState。所以，cursor=2 的时候对应的变量是 num2。而其实 num2 对应的 cursor 应该是 3。就会导致`setNum2`并不起作用。
+当点击事件触发再次渲染，并不会进入条件判断中的 useState。所以，cursor=2 的时候对应的变量是 num2。而其实 num2 对应的 cursor 应该是 1。就会导致`setNum2`并不起作用。
 
 到此，解决了文章开头提出的「🤔️ 为什么不能在循环、判断内部使用 Hook」。在使用 Hook 的时候，请在函数组件顶部使用！
 


### PR DESCRIPTION
当点击事件触发再次渲染，并不会进入条件判断中的 useState。所以，cursor=2 的时候对应的变量是 num2。而其实 num2 对应的 cursor 应该是 1。就会导致`setNum2`并不起作用。